### PR TITLE
Set up aws smtp email for all users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
-ruby '3.2.2'
+# ruby '3.2.2'
+# Accept any Ruby version >= 3.2.0 but < 4.0
+ruby '~> 3.0'
 
 gem 'dotenv-rails'
 

--- a/app/controllers/api/v1/authors/sessions_controller.rb
+++ b/app/controllers/api/v1/authors/sessions_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::Authors::SessionsController < Devise::SessionsController
     unless verify_recaptcha_token(params[:author][:captchaToken])
       return
     end
-  
+
     # Remove captchaToken to prevent Devise errors
     params[:author].delete(:captchaToken) if params[:author]&.key?(:captchaToken)
 
@@ -31,12 +31,16 @@ class Api::V1::Authors::SessionsController < Devise::SessionsController
       # First stage authentication with email/password
       self.resource = warden.authenticate!(auth_options)
 
-      # Handle authentication based on 2FA status
       if resource.two_factor_enabled?
+        # Handle 2FA if enabled
         handle_two_factor_authentication
       else
         # No 2FA required, complete login
         sign_in(resource_name, resource)
+
+        # ✅ Send welcome email asynchronously
+        AuthorMailer.welcome_email(resource).deliver_later
+
         respond_with(resource)
       end
     rescue => e
@@ -46,6 +50,7 @@ class Api::V1::Authors::SessionsController < Devise::SessionsController
       }, status: :unauthorized
     end
   end
+
 
 # Helper method for 2FA handling
   def handle_two_factor_authentication

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,0 +1,12 @@
+# app/mailers/admin_mailer.rb
+class AdminMailer < ApplicationMailer
+  default from: 'no-reply@itan.app' # Replace with your SES-verified email
+
+  def welcome_email(admin)
+    @admin = admin
+    mail(
+      to: @admin.email,
+      subject: 'Welcome to ITAN Admin Panel'
+    )
+  end
+end

--- a/app/mailers/author_mailer.rb
+++ b/app/mailers/author_mailer.rb
@@ -1,7 +1,8 @@
 class AuthorMailer < Devise::Mailer
   include Devise::Controllers::UrlHelpers
   default template_path: 'devise/mailer'
-  default from: 'omololuayk@gmail.com'
+  # default from: 'omololuayk@gmail.com'
+   default from: 'no-reply@itan.app' # SES-verified sender
 
   def confirmation_instructions(record, token, opts = {})
     @confirmation_url = "#{ENV['FRONTEND_URL']}/auth/confirm-email?confirmation_token=#{token}&email=#{record.email}"
@@ -40,6 +41,15 @@ class AuthorMailer < Devise::Mailer
     mail(
       to: @author.email,
       subject: "Your payment of $#{sprintf('%.2f', amount)} has been approved"
+    )
+  end
+
+   def welcome_email(author)
+    @author = author
+    mail(
+      to: @author.email,
+      subject: 'Welcome to ITAN Global Publishing!',
+      template_path: 'author_mailer'
     )
   end
 end

--- a/app/mailers/reader_mailer.rb
+++ b/app/mailers/reader_mailer.rb
@@ -1,0 +1,8 @@
+class ReaderMailer < ApplicationMailer
+  default from: 'no-reply@example.com'
+
+  def welcome_email(reader)
+    @reader = reader
+    mail(to: @reader.email, subject: 'Welcome to Our App!')
+  end
+end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,10 +1,19 @@
 class Admin < ApplicationRecord
   self.primary_key = :id
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+
+  # Include default devise modules
   devise :database_authenticatable, :recoverable,
          :rememberable, :validatable
 
   # associations
   has_many :notifications, as: :user
+
+  # Send welcome email after admin is created
+  # after_create :send_welcome_email
+
+  private
+
+  def send_welcome_email
+    AdminMailer.welcome_email(self).deliver_now
+  end
 end

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -3,24 +3,26 @@ class Author < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :confirmable,
+  :recoverable, :rememberable, :validatable, :confirmable,
          :omniauthable, omniauth_providers: [:google_oauth2]
-
-  # Email validation
+         
+         # Email validation
   validates :email, presence: true,
                     format: { with: URI::MailTo::EMAIL_REGEXP, message: 'must be a valid email address' },
                     uniqueness: { case_sensitive: false }
   validates :phone_number, format: { with: /\A\+?[\d\s\-\(\)]+\z/, allow_blank: true }
-
+  
   # associations
   has_many :notifications
   has_many :books
   has_many :author_revenues
   has_many :purchases, through: :books
   has_one :author_banking_detail, dependent: :destroy
-
+  
   # Active storage attachment
   has_one_attached :author_profile_image
+  
+  # after_create :send_welcome_email
 
   # 2FA methods
   def generate_two_factor_code!
@@ -146,6 +148,11 @@ class Author < ApplicationRecord
 
   def send_code_via_email(code)
     AuthorMailer.verification_code(self, code).deliver_now
+  end
+
+
+  def send_welcome_email
+    AuthorMailer.welcome_email(self).deliver_now
   end
 
   def send_code_via_sms(code)

--- a/app/models/reader.rb
+++ b/app/models/reader.rb
@@ -25,6 +25,8 @@ class Reader < ApplicationRecord
   validates :email, presence: true, uniqueness: true
   validates :first_name, :last_name, presence: true
 
+  # after_create :send_welcome_email
+
   # Helper methods for access checking
   def owns_book?(book)
     purchased_books.include?(book)
@@ -50,5 +52,12 @@ class Reader < ApplicationRecord
       trial_start: Time.current,
       trial_end: days.days.from_now
     )
+  end
+
+  private
+  def send_welcome_email
+    ReaderMailer.welcome_email(self).deliver_now
+  rescue StandardError => e
+    Rails.logger.error "Failed to send welcome email to #{email}: #{e.message}" 
   end
 end

--- a/app/views/admin_mailer/welcome_email.html.erb
+++ b/app/views/admin_mailer/welcome_email.html.erb
@@ -1,0 +1,4 @@
+<!-- app/views/admin_mailer/welcome_email.html.erb -->
+<h1>Hello <%= @admin.email %>,</h1>
+<p>Welcome to the ITAN Admin Dashboard.</p>
+<p>You now have administrative privileges. Use them responsibly!</p>

--- a/app/views/author_mailer/welcome_email.html.erb
+++ b/app/views/author_mailer/welcome_email.html.erb
@@ -1,0 +1,8 @@
+Hello <%= @author.first_name %>,
+
+Welcome to ITAN Global Publishing!
+
+We're excited to have you onboard as an author. You can now log in to your dashboard and start publishing your amazing work.
+
+Happy writing,
+The ITAN Team

--- a/app/views/reader_mailer/welcome_email.html.erb
+++ b/app/views/reader_mailer/welcome_email.html.erb
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <h1>Welcome, <%= [@reader.first_name, @reader.last_name].compact.join(" ") %>!</h1>
+    <p>Thank you for signing up. We're excited to have you on board.</p>
+    <p>— The Team</p>
+  </body>
+</html>

--- a/app/views/reader_mailer/welcome_text.html.erb
+++ b/app/views/reader_mailer/welcome_text.html.erb
@@ -1,0 +1,7 @@
+Welcome, <%= [@reader.first_name, @reader.last_name].compact.join(" ") %>!
+<p>
+  Thank you for signing up. We're excited to have you on board.
+</p>
+<p>
+  — The Team        
+</p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -81,13 +81,20 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   config.action_mailer.smtp_settings = {
-    address:       'smtp.gmail.com',
-    port:          587,
-    domain:         ENV['LOCAL_MAIL_HOST'], 
-    user_name:      ENV['SENDMAIL_USERNAME'],
-    password:       ENV['APP_SPEC_PASSWORD'],
-    authentication: :plain,
+    address:              'email-smtp.us-east-1.amazonaws.com', # Adjust region if needed
+    port:                 587,
+    user_name:            ENV['SES_SMTP_USERNAME'],
+    password:             ENV['SES_SMTP_PASSWORD'],
+    authentication:       :login,
     enable_starttls_auto: true,
+    # address:       'smtp.gmail.com',
+    port:          587,
+    # domain:         ENV['LOCAL_MAIL_HOST'], 
+    # domain:         'gmail.com',
+    # user_name:      ENV['SENDMAIL_USERNAME'],
+    # password:       ENV['APP_SPEC_PASSWORD'],
+    # authentication: :plain,
+    # enable_starttls_auto: true,
     openssl_verify_mode: 'none',
     open_timeout: 5.minutes,
     read_timeout: 5.minutes

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,13 +42,17 @@ Rails.application.configure do
   } 
   
   config.action_mailer.smtp_settings = {
-    address:       'smtp.gmail.com',
-    port:          587,
-    domain:         'gmail.com', 
-    user_name:      ENV['SENDMAIL_USERNAME'],
-    password:       ENV['APP_SPEC_PASSWORD'],
-    authentication: :plain,
-    enable_starttls_auto: true,
+    address: "email-smtp.us-east-1.amazonaws.com",
+    port: 587,
+    user_name: ENV['SES_SMTP_USERNAME'], # stored in ENV
+    password: ENV['SES_SMTP_PASSWORD'],  # stored in ENV
+    # address:       'smtp.gmail.com',
+    # port:          587,
+    # domain:         'gmail.com', 
+    # user_name:      ENV['SENDMAIL_USERNAME'],
+    # password:       ENV['APP_SPEC_PASSWORD'],
+    # authentication: :plain,
+    # enable_starttls_auto: true,
     openssl_verify_mode: 'none',
     open_timeout: 5.minutes,
     read_timeout: 5.minutes

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins "https://develop.dh6o3qh0ijr1u.amplifyapp.com", "https://itan.app", "https://publish.itan.app", "http://localhost:9000", "http://localhost:7000"
+    origins "https://develop.dh6o3qh0ijr1u.amplifyapp.com", "https://itan.app", "https://publish.itan.app", "http://localhost:9000", "http://localhost:7000", "http://localhost:8000"
 
     # Explicitly specify the ActiveStorage paths
     resource "/rails/active_storage/direct_uploads",


### PR DESCRIPTION
On this branch, I:
- updated the ruby gem version from `3.2.2` to  `~> 3.0` to support all ruby 3 versions.
- Set up aws SMTP in both development and production environments.
- Updated `admin`, `author` and `reader` mailers.
- added `admin`, `author` and `reader` mail helpers and views.
- Created and Tested for all users in `rails console`.