### PR TITLE
Fix 2FA email and sms verification flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+#Ignore Vendor
+/vendor/bundle/

--- a/app/controllers/api/v1/readers/two_factors_controller.rb
+++ b/app/controllers/api/v1/readers/two_factors_controller.rb
@@ -20,21 +20,53 @@ class Api::V1::Readers::TwoFactorsController < ApplicationController
 
   # === 2) Enable 2FA via email ===
   def enable_email
-    current_reader.update(
+    begin
+      # Update reader 2FA status for email
+      current_reader.update!(
+        two_factor_enabled: true,
+        preferred_2fa_method: 'email'
+      )
+
+      # Generate 6-digit 2FA code
+      code = generate_two_factor_code!(current_reader)
+
+      # Send code via email using ReaderMailer
+      # Make sure your ReaderMailer has a `two_factor_code_email` method defined
+      ReaderMailer.with(reader: current_reader, code: code).two_factor_code_email.deliver_later
+
+      render json: {
+        status: { code: 200, message: 'Two-factor authentication enabled via email. Code sent to your email.' }
+      }
+
+    rescue ActiveRecord::RecordInvalid => e
+      render json: { status: { code: 422, message: e.record.errors.full_messages.join(', ') } }, status: :unprocessable_entity
+    rescue NoMethodError => e
+      render json: { status: { code: 500, message: "Mailer method missing: #{e.message}" } }, status: :internal_server_error
+    rescue StandardError => e
+      render json: { status: { code: 500, message: "Failed to enable email 2FA: #{e.message}" } }, status: :internal_server_error
+    end
+  end
+
+  def verify_email_code
+  input_code = params[:verification_code]
+
+  if current_reader.two_factor_code == input_code && current_reader.two_factor_expires_at&.future?
+    current_reader.update!(
       two_factor_enabled: true,
-      preferred_2fa_method: 'email'
+      two_factor_code: nil,
+      two_factor_expires_at: nil
     )
 
-    # Generate email code
-    code = generate_two_factor_code(current_reader)
-
-    # Send code via email
-    ReaderMailer.with(reader: current_reader, code: code).two_factor_code_email.deliver_later
-
     render json: {
-      status: { code: 200, message: 'Two-factor authentication enabled via email. Code sent to email.' }
+      status: { code: 200, message: 'Two-factor authentication enabled via email.' }
     }
+  else
+    render json: {
+      status: { code: 422, message: 'Invalid or expired code.' }
+    }, status: :unprocessable_entity
   end
+end
+
 
   # === 3) Generate a 2FA code (can be reused for email or SMS) ===
   def generate_code
@@ -71,14 +103,28 @@ class Api::V1::Readers::TwoFactorsController < ApplicationController
 
   # === 5) Setup SMS 2FA ===
   def setup_sms
-    current_reader.update(phone_number: params[:phone_number])
-    code = generate_two_factor_code(current_reader)
-    
+    phone_number = params[:phone_number]
+
+    unless phone_number.present? && phone_number.match?(/\A\+\d{10,15}\z/)
+      return render json: { status: { code: 422, message: 'Invalid phone number format. Use +<countrycode><number>.' } }, status: :unprocessable_entity
+    end
+
     begin
+      # Update the reader with the new phone number
+      current_reader.update!(phone_number: phone_number)
+
+      # Generate a 6-digit 2FA code
+      code = generate_two_factor_code!(current_reader)
+
+      # Send code via SMS
       send_sms(current_reader.phone_number, code)
+
       render json: { status: { code: 200, message: 'Verification code sent via SMS' } }
+
+    rescue ActiveRecord::RecordInvalid => e
+      render json: { status: { code: 422, message: e.record.errors.full_messages.join(', ') } }, status: :unprocessable_entity
     rescue StandardError => e
-      render json: { status: { code: 422, message: "Failed to send SMS: #{e.message}" } }, status: :unprocessable_entity
+      render json: { status: { code: 500, message: "Failed to send SMS: #{e.message}" } }, status: :internal_server_error
     end
   end
 
@@ -111,20 +157,20 @@ class Api::V1::Readers::TwoFactorsController < ApplicationController
   private
 
   # Generate 6-digit code and save expiration
-  def generate_two_factor_code(reader)
+  def generate_two_factor_code!(reader)
     code = rand(100000..999999).to_s
-    reader.update(two_factor_code: code, two_factor_expires_at: 10.minutes.from_now)
+    reader.update!(two_factor_code: code, two_factor_expires_at: 10.minutes.from_now)
     code
   end
 
   # Send SMS via Twilio
   def send_sms(phone_number, code)
     client = Twilio::REST::Client.new(
-      ENV.fetch('TWILIO_ACCOUNT_SID', nil),
-      ENV.fetch('TWILIO_AUTH_TOKEN', nil)
+      ENV.fetch('TWILIO_ACCOUNT_SID'),
+      ENV.fetch('TWILIO_AUTH_TOKEN')
     )
     client.messages.create(
-      from: ENV.fetch('TWILIO_PHONE_NUMBER', nil),
+      from: ENV.fetch('TWILIO_PHONE_NUMBER'),
       to: phone_number,
       body: "Your Itan verification code is: #{code}"
     )

--- a/app/mailers/reader_mailer.rb
+++ b/app/mailers/reader_mailer.rb
@@ -41,6 +41,17 @@ class ReaderMailer < Devise::Mailer
     )
   end
 
+  #=== Two Factor Verification Code ===#
+  def two_factor_code_email
+    @reader = params[:reader]
+    @code   = params[:code]
+
+    mail(
+      to: @reader.email,
+      subject: "Your Itan Verification Code"
+    )
+  end
+
   private
 
   def generate_reading_token(purchase)

--- a/app/views/reader_mailer/two_factor_code_email.html.erb
+++ b/app/views/reader_mailer/two_factor_code_email.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @reader.email %>,</p>
+
+<p>Your two-factor verification code is:</p>
+<h2><%= @code %></h2>
+
+<p>This code will expire in 10 minutes.</p>
+<p>If you didn’t request this, ignore this email.</p>

--- a/app/views/reader_mailer/two_factor_code_email.text.erb
+++ b/app/views/reader_mailer/two_factor_code_email.text.erb
@@ -1,0 +1,6 @@
+Hello <%= @reader.email %>,
+
+Your two-factor verification code is: <%= @code %>
+
+This code will expire in 10 minutes.
+If you didn’t request this, ignore this message.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,6 +132,7 @@ Rails.application.routes.draw do
           post :enable_email
           post :setup_sms
           post :verify_sms
+          post :verify_email_code
           post :disable
         end
       end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_13_191805) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_21_085814) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -214,6 +214,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_13_191805) do
     t.text "message"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "reader_id"
     t.index ["user_type", "user_id"], name: "index_notifications_on_user"
   end
 


### PR DESCRIPTION
On this branch, I;
- Updated the routes by adding `verify_email` to the readers.
- Update the reader `two-factors` controller to handle verification email and sms.
- Created a Twilio account for credentials.
- Added `two_factor` method to the reader-mailer.
- Created `welcome_email` views for two-factor-authentication.
- Tested both email and sms on frontend.